### PR TITLE
Enable extends property in eslint configuration

### DIFF
--- a/lib/tasks/universal/analyze/index.js
+++ b/lib/tasks/universal/analyze/index.js
@@ -1,41 +1,18 @@
 'use strict';
 
-const fs = require('fs');
-
 const _ = require('lodash'),
     eslint = require('gulp-eslint'),
-    eslintRules = require('eslint-config-es/2015/server'),
     gulp = require('gulp');
 
 const defaultConfiguration = {
   src: [ '**/*.js', '!node_modules/**/*.js' ]
 };
 
-const tryRequire = function (packageName) {
-  try {
-    return require(packageName);
-  } catch (err) {
-    return null;
-  }
-};
-
 const analyze = function (roboter, userConfiguration) {
   const configuration = _.assign({}, defaultConfiguration, userConfiguration);
 
-  if (configuration.rules) {
-    if (typeof configuration.rules === 'string') {
-      let rules = tryRequire(configuration.rules);
-
-      if (!rules) {
-        rules = tryRequire('eslint-config-' + configuration.rules);
-        if (!rules) {
-          rules = JSON.parse(fs.readFileSync(configuration.rules));
-        }
-      }
-      configuration.rules = rules;
-    }
-  } else {
-    configuration.rules = eslintRules;
+  if (!configuration.rules) {
+    configuration.rules = 'eslint-config-es/2015/server';
   }
 
   gulp.task('_analyze', function () {

--- a/lib/tasks/universal/analyze/index.js
+++ b/lib/tasks/universal/analyze/index.js
@@ -11,11 +11,29 @@ const defaultConfiguration = {
   src: [ '**/*.js', '!node_modules/**/*.js' ]
 };
 
+const tryRequire = function (packageName) {
+  try {
+    return require(packageName);
+  } catch (err) {
+    return null;
+  }
+};
+
 const analyze = function (roboter, userConfiguration) {
   const configuration = _.assign({}, defaultConfiguration, userConfiguration);
 
   if (configuration.rules) {
-    configuration.rules = JSON.parse(fs.readFileSync(configuration.rules));
+    if (typeof configuration.rules === 'string') {
+      let rules = tryRequire(configuration.rules);
+
+      if (!rules) {
+        rules = tryRequire('eslint-config-' + configuration.rules);
+        if (!rules) {
+          rules = JSON.parse(fs.readFileSync(configuration.rules));
+        }
+      }
+      configuration.rules = rules;
+    }
   } else {
     configuration.rules = eslintRules;
   }

--- a/lib/tasks/universal/analyze/index.js
+++ b/lib/tasks/universal/analyze/index.js
@@ -5,15 +5,12 @@ const _ = require('lodash'),
     gulp = require('gulp');
 
 const defaultConfiguration = {
-  src: [ '**/*.js', '!node_modules/**/*.js' ]
+  src: [ '**/*.js', '!node_modules/**/*.js' ],
+  rules: 'eslint-config-es/2015/server'
 };
 
 const analyze = function (roboter, userConfiguration) {
   const configuration = _.assign({}, defaultConfiguration, userConfiguration);
-
-  if (!configuration.rules) {
-    configuration.rules = 'eslint-config-es/2015/server';
-  }
 
   gulp.task('_analyze', function () {
     return gulp.


### PR DESCRIPTION
Don't let the "analyze" task load eslint configuration by itself, instead pass the name of the file or package to gulp. This way eslint processes the "extends" property and a custom configuration can be build on top of a default configuration like the "eslint-config-es" package without repeating all rules.