### PR TITLE
Module 'minimist' is required but not included in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gulp-spawn-mocha": "2.2.2",
     "gulp-util": "3.0.7",
     "lodash": "4.12.0",
+    "minimist": "1.2.0",
     "node-sass": "3.7.0",
     "postcss-loader": "0.9.1",
     "raw-loader": "0.5.1",


### PR DESCRIPTION
Hi, I found a dependency that's missing in the package.json. :-)