### PR TITLE
Fix: Use hostname provided by configuration for DevServer.

### DIFF
--- a/lib/tasks/client/watch-app/index.js
+++ b/lib/tasks/client/watch-app/index.js
@@ -108,7 +108,7 @@ const watchApp = function (roboter, userConfiguration) {
       stats: { colors: true }
     });
 
-    server.listen(configuration.port, 'localhost', () => {
+    server.listen(configuration.port, configuration.host, () => {
       gutil.log(`I've built your app and put it here: http://${configuration.host}:${configuration.port}/`);
       done();
     });


### PR DESCRIPTION
Found a little bug inside the watch-app task. It always uses 'localhost' as hostname when starting the DevServer. This makes it impossible to preview apps in you local LAN via IP.

This little fix just uses the host provided by the configuration which enables the user to set the hostname to their IP address.