### PR TITLE
Added babelize option to watch-app and build-app tasks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ $ bot update --package lodash@4.13.1
 
 ### The `build-client` task
 
-This task builds a web application and consists of several sub-tasks that can be configured individually. As this configuration is completely optional roboter will fallback to sensible default values.
+This task builds a web application and consists of several sub-tasks that can be configured individually. As this configuration is completely optional roboter will fallback to sensible default values. In order to adjust the settings configure the `client/build-app` and the `client/copy-static` task.
 
 ```javascript
 task('client/build-app', {
@@ -393,6 +393,10 @@ task('client/build-app', {
     'src/index.html',
     'src/index.scss',
     'src/index.js'
+  ],
+  babelize: [
+    'src/',
+    'node_modules/my-es2015-dependency'
   ],
   buildDir: 'build/'
 });
@@ -454,7 +458,7 @@ Please note that you explicitly need to install plugins and presets in order for
 
 ### The `watch-client` task
 
-This task rebuilds a web application continuously. Additionally it starts a live-preview web server that will automatically refresh when files have been changed. By default, hot reloading is enabled for styles and React components.
+This task rebuilds a web application continuously. Additionally it starts a live-preview web server that will automatically refresh when files have been changed. By default, hot reloading is enabled for styles and React components. In order to adjust the settings used during watch mode configure the `client/watch-app` task.
 
 ```javascript
 task('client/watch-app', {
@@ -464,6 +468,10 @@ task('client/watch-app', {
     'src/index.js'
   ],
   buildDir: 'build/',
+  babelize: [
+    'src/',
+    'node_modules/my-es2015-dependency'
+  ],
   host: 'localhost',
   port: 8080,
   hotReloading: true

--- a/lib/tasks/client/build-app/index.js
+++ b/lib/tasks/client/build-app/index.js
@@ -18,6 +18,9 @@ const defaultConfiguration = {
     path.join(srcDirectory, 'index.scss'),
     path.join(srcDirectory, 'index.js')
   ],
+  babelize: [
+    srcDirectory
+  ],
   buildDir: buildDirectory
 };
 
@@ -38,6 +41,7 @@ const getWebpackConfiguration = function (configuration) {
         {
           test: /\.jsx?$/,
           exclude: /node_modules/,
+          include: configuration.babelize,
           loader: 'babel'
         }, {
           test: /\.html$/,

--- a/lib/tasks/client/watch-app/index.js
+++ b/lib/tasks/client/watch-app/index.js
@@ -21,6 +21,9 @@ const defaultConfiguration = {
     path.join(srcDirectory, 'index.js')
   ],
   buildDir: buildDirectory,
+  babelize: [
+    srcDirectory
+  ],
   host: 'localhost',
   port: 8080,
   hotReloading: true
@@ -49,7 +52,8 @@ const getWebpackConfiguration = function (configuration) {
       loaders: [
         {
           test: /\.jsx?$/,
-          include: srcDirectory,
+          exclude: /node_modules/,
+          include: configuration.babelize,
           loader: configuration.hotReloading && isReactUsed() ? 'react-hot!babel' : 'babel'
         }, {
           test: /\.html$/,


### PR DESCRIPTION
This is a proposal to get more fine graned access to the transpilation pipeline of your JS files in the client. With the help of the `babelize` option you can tell roboter to include additional resources into transpilation process. For example if you install an es2015 module via npm. 

I thought about several naming options for the feature (e.g. transpile, transpileJs, ...) but came to the conclusion that babel is the defacto-standard for transpilation. In the future the might be a whole bunch of babel plugins that you would like to add to your transpilation process. Therefore sticking to the tool name for this feature is ok for me in this situtation.

P.S. If you're ok with this feature and we've decided on a name we should merge it the master and test it via roboter-test before publishing a new version via NPM. I've already verified it works inside a local project but you never know :-)
