### PR TITLE
Added babelize option to test tasks.

### DIFF
--- a/lib/tasks/universal/test-integration/index.js
+++ b/lib/tasks/universal/test-integration/index.js
@@ -29,14 +29,20 @@ const testIntegration = function (roboter, userConfiguration) {
       return done(null);
     }
 
+    const mochaOptions = {
+      asyncOnly: configuration.asyncOnly,
+      bail: configuration.bail,
+      colors: true,
+      reporter: configuration.reporter,
+      ui: configuration.ui
+    };
+
+    if (configuration.babelize) {
+      mochaOptions.compilers = 'js:babel-register';
+    }
+
     const testStream = gulp.src(configuration.src, { read: false }).
-      pipe(mocha({
-        asyncOnly: configuration.asyncOnly,
-        bail: configuration.bail,
-        colors: true,
-        reporter: configuration.reporter,
-        ui: configuration.ui
-      })).
+      pipe(mocha(mochaOptions)).
       on('end', done);
 
     if (options.continuously) {

--- a/lib/tasks/universal/test-units/index.js
+++ b/lib/tasks/universal/test-units/index.js
@@ -29,14 +29,20 @@ const testUnits = function (roboter, userConfiguration) {
       return done(null);
     }
 
+    const mochaOptions = {
+      asyncOnly: configuration.asyncOnly,
+      bail: configuration.bail,
+      colors: true,
+      reporter: configuration.reporter,
+      ui: configuration.ui
+    };
+
+    if (configuration.babelize) {
+      mochaOptions.compilers = 'js:babel-register';
+    }
+
     const testStream = gulp.src(configuration.src, { read: false }).
-      pipe(mocha({
-        asyncOnly: configuration.asyncOnly,
-        bail: configuration.bail,
-        colors: true,
-        reporter: configuration.reporter,
-        ui: configuration.ui
-      })).
+      pipe(mocha(mochaOptions)).
       on('end', done);
 
     if (options.continuously) {


### PR DESCRIPTION
It's me and babel again :-)

I would like to propose an option to run mocha tests with babel compilation.

```javascript
task('universal/test-units', {
  babelize: true
});
````

This enables us to unit-test React components in Node with JsDom with the help of [enzyme](https://github.com/airbnb/enzyme/blob/master/docs/guides/mocha.md). A unit test for a ui-framework can then do the following things.

```javascript
import assert from 'assertthat';
import { mount } from 'enzyme';
/* eslint-disable no-unused-vars */
import React from 'react';
/* eslint-enable no-unused-vars */
import Tabs from '../../../src/components/Tabs.jsx';

import { createMemoryHistory, Route, Router } from 'react-router';

suite('Tabs', () => {
  it('renders default tabs.', done => {
    const wrapper = mount(<Tabs />);

    assert.that(wrapper.find('.ui-tabs__tab').length).is.equalTo(2);
    done();
  });
````
So on the one hand you can use JSX inside a mocha test and on the other hand it transpiles the JSX components that you require/import in your tests.

I haven't documented this because all the other mocha options are currently undocumented as well and therefore private. I would like to test this feature a bit more in production and see if it proves to be helpful. Once this is done we can add it to the docs.