### PR TITLE
Task unused-dependencies: Ignore roboter-client and roboter-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The environment you select defines what tasks are available to you. The exceptio
 - [`test`](#the-test-task)
 - [`test-integration`](#the-test-integration-task)
 - [`test-units`](#the-test-units-task)
+- [`unused-dependencies`](#the-unused-dependencies-task)
 - [`update`](#the-update-task)
 
 ### Client tasks
@@ -418,6 +419,24 @@ task('universal/test-units', {
 ```
 
 *Please note that the `post` task is always run, even in case of failing tests.*
+
+### The `unused-dependencies` task
+
+This task searches for dependencies that are not required anywhere in your source code.
+
+To run this task use the following command.
+
+```bash
+$ bot unused-dependencies
+```
+
+By default, the directory `node_modules` is excluded from the search. If you want to exclude additional directories, use the `exclude` property.
+
+```javascript
+task('universal/unused-dependencies', {
+  exclude: [ 'foo/bar', 'node_modules' ]
+});
+```
 
 ### The `update` task
 

--- a/lib/tasks/universal/unused-dependencies/index.js
+++ b/lib/tasks/universal/unused-dependencies/index.js
@@ -15,7 +15,7 @@ const unusedDependencies = function (roboter, userConfiguration) {
   gulp.task('_unused-dependencies', done => {
     depcheck({
       ignoreDirs: configuration.exclude,
-      ignoreMatches: []
+      ignoreMatches: [ 'roboter-client', 'roboter-server' ]
     })().
       then(done).
       catch(err => {


### PR DESCRIPTION
I found a little bug caused by the separation of roboter's client and server part.

One of the modules `roboter-client` and `roboter-server` must be present in the `package.json` without being explicitly required in the source code. This leads to a false error when using the task `unused-dependencies`. I added the modules to the ignore list.

BTW: I also added a description for the task. 😉