### PR TITLE
Add custom gulp tasks that can be combined with existing roboter tasks

### DIFF
--- a/lib/roboter.js
+++ b/lib/roboter.js
@@ -7,6 +7,7 @@ const gulp = require('gulp');
 
 const Roboter = function () {
   this.tasks = {};
+  this.customTasks = {};
   this.useFolder('universal');
   this.isWatching = false;
 };
@@ -21,6 +22,23 @@ Roboter.prototype.use = function (taskName, configuration) {
     configuration,
     directory: path.join(__dirname, 'tasks', taskNamePartials[0], taskNamePartials[1])
   };
+};
+
+Roboter.prototype.useCustom = function (taskName, dependencies, task) {
+  if (!task && typeof dependencies === 'function') {
+    task = dependencies;
+    dependencies = undefined;
+  }
+  dependencies = dependencies || [];
+  task = task || function () {}; // no-op
+
+  this.customTasks[taskName] = {
+    name: taskName,
+    dependencies,
+    task
+  };
+
+  return this;
 };
 
 Roboter.prototype.useFolder = function (environment) {
@@ -62,6 +80,15 @@ Roboter.prototype.start = function () {
     if (taskName.startsWith('_')) {
       gulp.task(taskName.substring(1), [ taskName ]);
     }
+  });
+
+  // handle custom tasks, they can't override roboter tasks.
+  Object.keys(this.customTasks).forEach(taskName => {
+    if(taskName.indexOf('custom-') !== 0) {
+      throw new Error(`Custom task ${taskName} must start with the prefix 'custom-'.`);
+    }
+
+    gulp.task(taskName, this.customTasks[taskName].dependencies, this.customTasks[taskName].task);
   });
 
   // Register aliases for public tasks.

--- a/lib/tasks/universal/update/index.js
+++ b/lib/tasks/universal/update/index.js
@@ -138,7 +138,7 @@ const update = function (roboter, userConfiguration) {
 
             shell.exec(`git ls-remote --tags ${repository}`, { silent: true }, (errLsRemote, stdout) => {
               if (errLsRemote) {
-                return doneEach2(errLsRemote);
+                return doneEach2({stack: `${errLsRemote} - Failed to list tags`});
               }
 
               const semverTags = stdout.match(/\d+\.\d+\.\d+$/gm);
@@ -155,13 +155,7 @@ const update = function (roboter, userConfiguration) {
           } else {
             doneEach2(null);
           }
-        }, errEach2 => {
-          if(errEach2) {
-            return doneEach1(errEach2);
-          }
-
-          doneEach1(null);
-        });
+        }, doneEach1);
       }, errEach => {
 
         if (errEach) {

--- a/lib/tasks/universal/update/index.js
+++ b/lib/tasks/universal/update/index.js
@@ -132,7 +132,9 @@ const update = function (roboter, userConfiguration) {
             packagesToUpdate[dependencyType][packageName].repository &&
             !packagesToUpdate[dependencyType][packageName].wanted
           ) {
-            const repository = packagesToUpdate[dependencyType][packageName].repository.replace('git+ssh://', '');
+            const repository = packagesToUpdate[dependencyType][packageName].repository
+              .replace('git+ssh://', '')
+              .replace('git+https://', '');
 
             shell.exec(`git ls-remote --tags ${repository}`, { silent: true }, (errLsRemote, stdout) => {
               if (errLsRemote) {
@@ -153,23 +155,23 @@ const update = function (roboter, userConfiguration) {
           } else {
             doneEach2(null);
           }
-        }, doneEach1);
+        }, errEach2 => {
+          if(errEach2) {
+            return doneEach1(errEach2);
+          }
+
+          doneEach1(null);
+        });
       }, errEach => {
+
         if (errEach) {
           return done(errEach);
         }
 
-        // Remove dependency types that don't need to be updated.
-        dependencyTypes.forEach(dependencyType => {
-          if (Object.keys(packagesToUpdate[dependencyType]).length === 0) {
-            Reflect.deleteProperty(packagesToUpdate, dependencyType);
-          }
-        });
-
         // Build installation paths and run npm.
         async.series([
           cb => {
-            if (packagesToUpdate.dependencies.length === 0) {
+            if (!packagesToUpdate.dependencies || packagesToUpdate.dependencies.length === 0) {
               return cb(null);
             }
 
@@ -194,7 +196,7 @@ const update = function (roboter, userConfiguration) {
             });
           },
           cb => {
-            if (packagesToUpdate.devDependencies.length === 0) {
+            if (!packagesToUpdate.devDependencies || packagesToUpdate.devDependencies.length === 0) {
               return cb(null);
             }
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     {
       "name": "Matthias Wagler",
       "email": "matthias.wagler@thenativeweb.io"
+    },
+    {
+      "name": "Joachim Haecker-Becker",
+      "email": "joachim.haecker-becker@arcor.de"
     }
   ],
   "main": "lib/roboter.js",


### PR DESCRIPTION
My use case was to add some steps in the bot release task, so after analyze+test-units but before checking git etc.

The useCustom function on the roboter has the same syntax as gulp.task(...), returns the instance so it can be chained.
taskNames must be prefixed with 'custom-' (Error if not), but there may be use cases to overwrite existing?

Example Usage:

````
const roboter = require('roboter');

roboter
  .workOn('server')
  .useCustom('custom-release', [], function(done) {
    runSequence(
      'analyze',
      'test-units',
      'unused-dependencies',
      'outdated',
      'custom-build',
      'custom-commit-dist',
      '_release-force',
      done
    );
  })
  .start();

// will allow: bot custom-release
````

What do you think?