### PR TITLE
Add node_modules folder as basePath for sass loader.

### DIFF
--- a/lib/tasks/client/build-app/index.js
+++ b/lib/tasks/client/build-app/index.js
@@ -61,6 +61,11 @@ const getWebpackConfiguration = function (configuration) {
       ]
     },
     postcss: [ autoprefixer() ],
+    sassLoader: {
+      includePaths: [
+        './node_modules'
+      ]
+    },
     plugins: [
       // Set NODE_ENV to production in order for React to exclude its dev warnings.
       new webpack.DefinePlugin({

--- a/lib/tasks/client/watch-app/index.js
+++ b/lib/tasks/client/watch-app/index.js
@@ -72,6 +72,11 @@ const getWebpackConfiguration = function (configuration) {
       ]
     },
     postcss: [ autoprefixer() ],
+    sassLoader: {
+      includePaths: [
+        './node_modules'
+      ]
+    },
     plugins: [
       new webpack.HotModuleReplacementPlugin(),
       new webpack.NoErrorsPlugin()


### PR DESCRIPTION
This PR adds the ability to simplify importing `.scss` files from `node_modules`. For example [grommet](https://github.com/grommet/grommet) is [importing](https://github.com/grommet/grommet/blob/2c31344f819081509301b403f0cb034b12ee088b/src/scss/grommet-core/index.scss#L6) the [inuit-normalize](https://github.com/inuitcss/generic.normalize) package which is installed as npm dependency just like any other JS module. 

Both `client/watch-app` and `client/build-app` now use the [includePaths](https://github.com/sass/node-sass#includepaths) options of node-sass to specify `node_modules` as a possible source for scss files. This options is simply passed to SassLoader inside the webpack config.
