### PR TITLE
bot analyze: Ignore coverage directory.

### DIFF
--- a/lib/tasks/universal/analyze/index.js
+++ b/lib/tasks/universal/analyze/index.js
@@ -5,7 +5,7 @@ const _ = require('lodash'),
       gulp = require('gulp');
 
 const defaultConfiguration = {
-  src: [ '**/*.js', '!node_modules/**/*.js' ],
+  src: [ '**/*.js', '!coverage/**/*.js', '!node_modules/**/*.js' ],
   rules: 'eslint-config-es/2015/server'
 };
 


### PR DESCRIPTION
`bot coverage` creates the directory `coverage`. Unfortunately, a subsequent `bot analyze` reports a few thousand errors. Instead, it should ignore this directory by default.