### PR TITLE
Fix watch-server after 1 test fails

### DIFF
--- a/lib/tasks/universal/test/index.js
+++ b/lib/tasks/universal/test/index.js
@@ -20,14 +20,14 @@ const test = function (roboter, userConfiguration) {
 
   gulp.task('_watch-test-continuously', done => {
     sequence(
-      'test-units-continuously',
-      'test-integration-continuously',
+      '_test-units-continuously',
+      '_test-integration-continuously',
       done);
   });
 
   gulp.task('_watch-test', () => {
     roboter.isWatching = true;
-    gulp.watch(configuration.watch, [ 'watch-test-continuously' ]);
+    gulp.watch(configuration.watch, [ '_watch-test-continuously' ]);
   });
 };
 


### PR DESCRIPTION
So after some debugging i saw that the tasks for continuously test are given with public names into gulp-sequence, while they run as internal task name.

Debugging within gulp-sequence:

Output:
gulp-sequence / runSequence -> errorListener [ 'test-units-continuously' ] -1 { task: '_test-units-continuously'.... }

gulp-sequence/index.js line: 51
function errorListener (e) {
          console.log(`gulp-sequence / runSequence -> errorListener`, task, task.indexOf(e.task), e);
          if (!e.err || task.indexOf(e.task) < 0) return

          console.log(`gulp-sequence / runSequence -> errorListener`, 'removeListener()', 'callback()');

          removeListener()
          callback(e.err)
        }

Not sure if this change should be adapted to all runSequence calls.