### PR TITLE
Introduce define option to watch-app and build-app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,28 @@ To compile your JavaScript code using Babel, add a `.babelrc` file to your appli
 
 Please note that you explicitly need to install plugins and presets in order for this to work.
 
+#### Configuring the client by defining globals
+
+You can use the `define` option of the `build-app` task to make your client configurable from outside. This can be helpful e.g. to set properties that differ between development and production environments.
+
+```javascript
+task('client/build-app', {
+  define: {
+    'process.env.API_HOST': 'my.api.com'
+  }
+});
+```
+
+In this example roboter will replace all the strings `process.env.API_HOST` inside your client code with the string `"my.api.com"`.
+
+```javascript
+// That line…
+console.log(process.env.API_HOST);
+
+// … will be compiled into this line.
+console.log("my.api.com");
+```
+
 ### The `watch-client` task
 
 This task rebuilds a web application continuously. Additionally it starts a live-preview web server that will automatically refresh when files have been changed. By default, hot reloading is enabled for styles and React components. In order to adjust the settings used during watch mode configure the `client/watch-app` task.

--- a/lib/tasks/client/build-app/index.js
+++ b/lib/tasks/client/build-app/index.js
@@ -17,12 +17,22 @@ const defaultConfiguration = {
   babelize: [
     srcDirectory
   ],
+  define: {
+    __DEV__: false,
+    'process.env.NODE_ENV': 'production'
+  },
   basePath: '/',
   buildDir: buildDirectory,
   entryFiles: glob.sync(path.join(srcDirectory, 'index.*'))
 };
 
 const getWebpackConfiguration = function (configuration) {
+  const definitions = {};
+
+  Object.keys(configuration.define).forEach(key => {
+    definitions[key] = JSON.stringify(configuration.define[key]);
+  });
+
   return {
     bail: true,
     context: srcDirectory,
@@ -67,10 +77,7 @@ const getWebpackConfiguration = function (configuration) {
       publicPath: configuration.basePath
     },
     plugins: [
-      new webpack.DefinePlugin({
-        __DEV__: false,
-        'process.env.NODE_ENV': JSON.stringify('production')
-      }),
+      new webpack.DefinePlugin(definitions),
       new webpack.optimize.OccurrenceOrderPlugin(),
       new webpack.optimize.UglifyJsPlugin({ compress: { warnings: false }})
     ],
@@ -79,7 +86,7 @@ const getWebpackConfiguration = function (configuration) {
 };
 
 const buildApp = function (roboter, userConfiguration) {
-  const configuration = _.assign({}, defaultConfiguration, userConfiguration);
+  const configuration = _.merge({}, defaultConfiguration, userConfiguration);
   const webpackConfiguration = getWebpackConfiguration(configuration);
 
   gulp.task('_build-app', done => {

--- a/lib/tasks/client/watch-app/index.js
+++ b/lib/tasks/client/watch-app/index.js
@@ -20,6 +20,9 @@ const defaultConfiguration = {
     srcDirectory
   ],
   buildDir: buildDirectory,
+  define: {
+    'process.env.NODE_ENV': 'development'
+  },
   entryFiles: glob.sync(path.join(srcDirectory, 'index.*')),
   host: 'localhost',
   hotReloading: true,
@@ -33,6 +36,12 @@ const isReactUsed = function () {
 };
 
 const getWebpackConfiguration = function (configuration) {
+  const definitions = {};
+
+  Object.keys(configuration.define).forEach(key => {
+    definitions[key] = JSON.stringify(configuration.define[key]);
+  });
+
   return {
     bail: false,
     context: srcDirectory,
@@ -81,6 +90,7 @@ const getWebpackConfiguration = function (configuration) {
       publicPath: `${configuration.https ? 'https' : 'http'}://${configuration.host}:${configuration.port}/`
     },
     plugins: [
+      new webpack.DefinePlugin(definitions),
       new webpack.HotModuleReplacementPlugin(),
       new webpack.NoEmitOnErrorsPlugin()
     ],
@@ -89,7 +99,7 @@ const getWebpackConfiguration = function (configuration) {
 };
 
 const watchApp = function (roboter, userConfiguration) {
-  const configuration = _.assign({}, defaultConfiguration, userConfiguration);
+  const configuration = _.merge({}, defaultConfiguration, userConfiguration);
   const webpackConfiguration = getWebpackConfiguration(configuration);
   const baseUrl = `${configuration.https ? 'https' : 'http'}://${configuration.host}:${configuration.port}/`;
 


### PR DESCRIPTION
This PR introduces a `define` option to the watch and build client tasks to make SPAs configurable during the build step. 

There is one change that might cause problems for existing applications. I had to switch from `_.assign` to `_.merge` for merging user configurations as `assign` won't merge child objects. Otherwise I wasn't able to merge the default `define` options into the ones specified by the user.