### PR TITLE
Add new licenses.

### DIFF
--- a/configuration/licenseCompatibility.js
+++ b/configuration/licenseCompatibility.js
@@ -22,7 +22,9 @@ const licenseCompatibility = {
     '(BSD-2-Clause OR MIT OR Apache-2.0)',
     'BSD-3-Clause OR MIT',
     '(GPL-2.0 OR MIT)',
+    '(MIT AND BSD-3-Clause)',
     '(MIT AND CC-BY-3.0)',
+    '(MIT AND Zlib)',
     '(MIT OR Apache-2.0)',
     '(WTFPL OR MIT)'
   ],
@@ -48,7 +50,9 @@ const licenseCompatibility = {
     '(BSD-2-Clause OR MIT OR Apache-2.0)',
     'BSD-3-Clause OR MIT',
     '(GPL-2.0 OR MIT)',
+    '(MIT AND BSD-3-Clause)',
     '(MIT AND CC-BY-3.0)',
+    '(MIT AND Zlib)',
     '(MIT OR Apache-2.0)',
     '(WTFPL OR MIT)'
   ]


### PR DESCRIPTION
I have added two new licenses:

- MIT and ZLib
- MIT and BSD-3-Clause

We had already considered MIT and BSD-3-Clause to be compatible, so their combination should also be valid.

ZLib is considered to be compatible to MIT and also GPL, according to [Wikipedia](https://en.wikipedia.org/wiki/Zlib_License).