### PR TITLE
Add license whitelist for wolkenkit-react.

### DIFF
--- a/configuration/whitelistedPackages.js
+++ b/configuration/whitelistedPackages.js
@@ -5,6 +5,11 @@ const whitelistedPackages = {
     'commands-events',
     'wolkenkit',
     'wolkenkit-eventstore'
+  ],
+  'wolkenkit-react': [
+    'commands-events',
+    'wolkenkit',
+    'wolkenkit-eventstore'
   ]
 };
 


### PR DESCRIPTION
In order to fix thenativeweb/wolkenkit#108 we must release a new version of wolkenkit-react. In order to do that we first need to update the license whitelist for this package. Once this PR is merged you can create a new minor version of `wolkenkit-react` and publish it to npm.