### PR TITLE
Add check for release type and error in case it is unknown.

### DIFF
--- a/lib/cli/commands/release.js
+++ b/lib/cli/commands/release.js
@@ -66,7 +66,7 @@ const release = {
 
     try {
       if (![ 'patch', 'minor', 'major' ].includes(type)) {
-        const errorMessage = `Release type 'nonsense' is not supported. Choose one of 'patch', 'minor' or 'major'.`;
+        const errorMessage = `Invalid release type '${type}'. Use 'patch', 'minor' or 'major'.`;
 
         ui.error(errorMessage);
         throw new errors.ReleaseTypeNotSupported(errorMessage);

--- a/lib/cli/commands/release.js
+++ b/lib/cli/commands/release.js
@@ -7,6 +7,7 @@ const analyseTask = require('../tasks/analyse'),
       bumpProjectVersionTask = require('../tasks/bumpProjectVersion'),
       checkLicenseCompatibilityTask = require('../tasks/checkLicenseCompatibility'),
       dependenciesTask = require('../tasks/dependencies'),
+      errors = require('../../errors'),
       files = require('../../files'),
       globalOptionDefinitions = require('../globalOptionDefinitions'),
       isGitInReleasableStateTask = require('../tasks/isGitInReleasableState'),
@@ -64,6 +65,13 @@ const release = {
     ui.printTaskHeader('release');
 
     try {
+      if (![ 'patch', 'minor', 'major' ].includes(type)) {
+        const errorMessage = `Release type 'nonsense' is not supported. Choose one of 'patch', 'minor' or 'major'.`;
+
+        ui.error(errorMessage);
+        throw new errors.ReleaseTypeNotSupported(errorMessage);
+      }
+
       if (!force) {
         await analyseTask({ directory, ui });
         await testCodeTask({ directory, ui });

--- a/lib/cli/commands/release.js
+++ b/lib/cli/commands/release.js
@@ -69,7 +69,7 @@ const release = {
         const errorMessage = `Invalid release type '${type}'. Use 'patch', 'minor' or 'major'.`;
 
         ui.error(errorMessage);
-        throw new errors.ReleaseTypeNotSupported(errorMessage);
+        throw new errors.ReleaseTypeInvalid(errorMessage);
       }
 
       if (!force) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -24,6 +24,7 @@ const errors = defekt({
   OutdatedNodeReference: {},
   PackageJsonMissing: {},
   PendingChanges: {},
+  ReleaseTypeNotSupported: {},
   StepExecutionFailed: {},
   TestsFailed: {},
   TypeScriptCompilationFailed: {},

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -24,7 +24,7 @@ const errors = defekt({
   OutdatedNodeReference: {},
   PackageJsonMissing: {},
   PendingChanges: {},
-  ReleaseTypeNotSupported: {},
+  ReleaseTypeInvalid: {},
   StepExecutionFailed: {},
   TestsFailed: {},
   TypeScriptCompilationFailed: {},

--- a/test/integration/release/fails-on-invalid-release-type/args.js
+++ b/test/integration/release/fails-on-invalid-release-type/args.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  type: 'nonsense'
+};

--- a/test/integration/release/fails-on-invalid-release-type/expected.js
+++ b/test/integration/release/fails-on-invalid-release-type/expected.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const exitCode = 1;
+
+const stdout = '';
+
+const stderr = `✗ Release type 'nonsense' is not supported. Choose one of 'patch', 'minor' or 'major'.
+✗ Failed to release.`;
+
+module.exports = { exitCode, stdout, stderr };

--- a/test/integration/release/fails-on-invalid-release-type/expected.js
+++ b/test/integration/release/fails-on-invalid-release-type/expected.js
@@ -4,7 +4,7 @@ const exitCode = 1;
 
 const stdout = '';
 
-const stderr = `✗ Release type 'nonsense' is not supported. Choose one of 'patch', 'minor' or 'major'.
+const stderr = `✗ Invalid release type 'nonsense'. Use 'patch', 'minor' or 'major'.
 ✗ Failed to release.`;
 
 module.exports = { exitCode, stdout, stderr };

--- a/test/integration/release/fails-on-invalid-release-type/package.json
+++ b/test/integration/release/fails-on-invalid-release-type/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test-package",
+  "version": "0.0.1"
+}


### PR DESCRIPTION
I noticed that we don't explicitly check the release type in the `release` command, so I added a check and a test for it.