### PR TITLE
Run only TypeScript tests in TypeScript projects.

### DIFF
--- a/lib/cli/tasks/testCode.js
+++ b/lib/cli/tasks/testCode.js
@@ -2,6 +2,8 @@
 
 const path = require('path');
 
+const isTypeScript = require('is-typescript').default;
+
 const files = require('../../files'),
       loadEnvironmentVariables = require('../../steps/test/loadEnvironmentVariables'),
       runLifecycleStep = require('../../steps/test/runLifecycleStep'),
@@ -27,6 +29,8 @@ const testCodeTask = async function ({ directory, type, ui }) {
       return;
     }
 
+    const testTypeScriptFiles = await isTypeScript({ directory });
+
     const ignoredDirectories = [ 'shared' ],
           preferredTypes = [ 'unit', 'integration', 'e2e', 'performance' ];
     let types = [ type || await files.getSubDirectories({ directory: testDirectory }) ].flat();
@@ -47,7 +51,7 @@ const testCodeTask = async function ({ directory, type, ui }) {
 
       const testFiles = await files.get({
         directory,
-        pattern: `test/${currentType}/**/*Tests.(j|t)s`
+        pattern: `test/${currentType}/**/*Tests.${testTypeScriptFiles ? 't' : 'j'}s`
       });
 
       if (!testFiles || testFiles.length === 0) {

--- a/test/integration/test/runs-only-typescript-tests-if-mixed/expected.js
+++ b/test/integration/test/runs-only-typescript-tests-if-mixed/expected.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const assert = require('assertthat').default;
+
+const exitCode = 0;
+
+const stdoutTest = 'unit tests successful.';
+
+const stderr = '';
+
+const validate = async function ({
+  stdout
+}) {
+  assert.that(stdout).is.not.containing('javascript');
+  assert.that(stdout).is.containing('typescript');
+};
+
+module.exports = { exitCode, stdout: stdoutTest, stderr, validate };

--- a/test/integration/test/runs-only-typescript-tests-if-mixed/package.json
+++ b/test/integration/test/runs-only-typescript-tests-if-mixed/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-package",
+  "version": "0.0.1",
+  "devDependencies": {
+    "assertthat": "4.0.1"
+  }
+}

--- a/test/integration/test/runs-only-typescript-tests-if-mixed/test/unit/javascriptTests.js
+++ b/test/integration/test/runs-only-typescript-tests-if-mixed/test/unit/javascriptTests.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const assert = require('assertthat').default;
+
+suite('typescript unit tests', () => {
+  test('run successfully.', async () => {
+    /* eslint-disable no-console */
+    console.log('javascript');
+    /* eslint-enable no-console */
+    assert.that(true).is.true();
+  });
+});

--- a/test/integration/test/runs-only-typescript-tests-if-mixed/test/unit/unitTests.ts
+++ b/test/integration/test/runs-only-typescript-tests-if-mixed/test/unit/unitTests.ts
@@ -1,0 +1,10 @@
+import assert from 'assertthat';
+
+suite('typescript unit tests', (): void => {
+  test('run successfully.', async (): Promise<void> => {
+    /* eslint-disable no-console */
+    console.log('typescript');
+    /* eslint-enable no-console */
+    assert.that(true).is.true();
+  });
+});

--- a/test/integration/test/runs-only-typescript-tests-if-mixed/tsconfig.json
+++ b/test/integration/test/runs-only-typescript-tests-if-mixed/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declaration": true,
+    "esModuleInterop": true,
+    "lib": [ "esnext" ],
+    "module": "commonjs",
+    "outDir": "build",
+    "resolveJsonModule": true,
+    "strict": true,
+    "target": "es2019"
+  },
+  "include": [
+    "./**/*.ts"
+  ]
+}


### PR DESCRIPTION
So that in TypeScript projects JavaScript tests are ignored (and the other way around), as is currently the case in the wolkenkit development.