### PR TITLE
Implement global pre- and post-hook for tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ If you need to register any additional pre or post actions (such as starting or 
 
 #### Setting up and tearing down tests globally
 
-If you need to set something up and tear something down across all of your test types, add a `pre.js` and `post.js` (or `pre.ts` and `post.ts`) in the `test` folder of your project. These function just like the test specific pre/post tasks above but are only run once before and after all tests.
+If you need to set something up and tear something down across all of your test types, add a `pre.js` and `post.js` (or `pre.ts` and `post.ts`) in the `test` folder of your project. These work just like the test specific pre/post tasks above but are only run once before and after all tests.
 
 #### Setting environment variables
 

--- a/README.md
+++ b/README.md
@@ -359,6 +359,10 @@ If you need to register any additional pre or post actions (such as starting or 
 
 *Please note: The `post.js` respectively `post.ts` file will be run no matter whether the tests themselves were run successfully or not.*
 
+#### Setting up and tearing down tests globally
+
+If you need to set something up and tear something down across all of your test types, add a `pre.js` and `post.js` (or `pre.ts` and `post.ts`) in the `test` folder of your project. These function just like the test specific pre/post tasks above but are only run once before and after all tests.
+
 #### Setting environment variables
 
 To set environment variables that are available in the tests, you can create a `.env` file per test type:

--- a/lib/cli/tasks/testCode.js
+++ b/lib/cli/tasks/testCode.js
@@ -17,10 +17,11 @@ const testCodeTask = async function ({ directory, type, ui }) {
     throw new Error('UI is missing.');
   }
 
+  const testDirectory = path.join(directory, 'test');
+
   try {
     ui.printTaskHeader('tests');
 
-    const testDirectory = path.join(directory, 'test');
     const doesTestDirectoryExist = await files.exists({ path: testDirectory });
 
     if (!doesTestDirectoryExist) {
@@ -44,6 +45,12 @@ const testCodeTask = async function ({ directory, type, ui }) {
         types.splice(index, 1);
         types.unshift(preferredType);
       }
+    });
+
+    ui.printTaskHeader(`global pre step`);
+    await runLifecycleStep({
+      directory: path.join(testDirectory),
+      step: 'pre'
     });
 
     for (const currentType of types) {
@@ -104,6 +111,12 @@ const testCodeTask = async function ({ directory, type, ui }) {
         ui.error('Failed to run tests.');
         throw ex;
     }
+  } finally {
+    ui.printTaskHeader(`global post step`);
+    await runLifecycleStep({
+      directory: path.join(testDirectory),
+      step: 'post'
+    });
   }
 };
 

--- a/test/integration/test/runs-global-post-task-on-crashing-tests/expected.js
+++ b/test/integration/test/runs-global-post-task-on-crashing-tests/expected.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const exitCode = 1;
+
+const stdout = [
+  `Hello from global pre task!`,
+  `Hello from global post task!`
+];
+
+const stderr = '✗ Tests failed.';
+
+module.exports = { exitCode, stdout, stderr };

--- a/test/integration/test/runs-global-post-task-on-crashing-tests/package.json
+++ b/test/integration/test/runs-global-post-task-on-crashing-tests/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-package",
+  "version": "0.0.1",
+  "devDependencies": {
+    "assertthat": "5.0.2"
+  }
+}

--- a/test/integration/test/runs-global-post-task-on-crashing-tests/test/post.js
+++ b/test/integration/test/runs-global-post-task-on-crashing-tests/test/post.js
@@ -1,0 +1,5 @@
+'use strict';
+
+/* eslint-disable no-console */
+console.log('Hello from global post task!');
+/* eslint-enable no-console */

--- a/test/integration/test/runs-global-post-task-on-crashing-tests/test/pre.js
+++ b/test/integration/test/runs-global-post-task-on-crashing-tests/test/pre.js
@@ -1,0 +1,5 @@
+'use strict';
+
+/* eslint-disable no-console */
+console.log('Hello from global pre task!');
+/* eslint-enable no-console */

--- a/test/integration/test/runs-global-post-task-on-crashing-tests/test/unit/sampleTests.js
+++ b/test/integration/test/runs-global-post-task-on-crashing-tests/test/unit/sampleTests.js
@@ -1,0 +1,9 @@
+'use strict';
+
+suite('sample', () => {
+  test('fails.', async () => {
+    /* eslint-disable unicorn/no-process-exit */
+    process.exit(1);
+    /* eslint-enable unicorn/no-process-exit */
+  });
+});

--- a/test/integration/test/runs-global-post-task-on-failing-tests/expected.js
+++ b/test/integration/test/runs-global-post-task-on-failing-tests/expected.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const exitCode = 1;
+
+const stdout = [
+  `Hello from global pre task!`,
+  `Hello from global post task!`
+];
+
+const stderr = '✗ Tests failed.';
+
+module.exports = { exitCode, stdout, stderr };

--- a/test/integration/test/runs-global-post-task-on-failing-tests/package.json
+++ b/test/integration/test/runs-global-post-task-on-failing-tests/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-package",
+  "version": "0.0.1",
+  "devDependencies": {
+    "assertthat": "5.0.2"
+  }
+}

--- a/test/integration/test/runs-global-post-task-on-failing-tests/test/post.js
+++ b/test/integration/test/runs-global-post-task-on-failing-tests/test/post.js
@@ -1,0 +1,5 @@
+'use strict';
+
+/* eslint-disable no-console */
+console.log('Hello from global post task!');
+/* eslint-enable no-console */

--- a/test/integration/test/runs-global-post-task-on-failing-tests/test/pre.js
+++ b/test/integration/test/runs-global-post-task-on-failing-tests/test/pre.js
@@ -1,0 +1,5 @@
+'use strict';
+
+/* eslint-disable no-console */
+console.log('Hello from global pre task!');
+/* eslint-enable no-console */

--- a/test/integration/test/runs-global-post-task-on-failing-tests/test/unit/sampleTests.js
+++ b/test/integration/test/runs-global-post-task-on-failing-tests/test/unit/sampleTests.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const { assert } = require('assertthat');
+
+suite('sample', () => {
+  test('fails.', done => {
+    assert.that(true).is.false();
+    done();
+  });
+});

--- a/test/integration/test/runs-global-pre-and-post-tasks/expected.js
+++ b/test/integration/test/runs-global-pre-and-post-tasks/expected.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const exitCode = 0;
+
+const stdout = [
+  'Hello from global pre task!',
+  'Hello from unit test!',
+  'unit tests successful.',
+  'Hello from integration test!',
+  'integration tests successful.',
+  'Hello from global post task!'
+];
+
+const stderr = '';
+
+module.exports = { exitCode, stdout, stderr };

--- a/test/integration/test/runs-global-pre-and-post-tasks/package.json
+++ b/test/integration/test/runs-global-pre-and-post-tasks/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-package",
+  "version": "0.0.1",
+  "devDependencies": {
+    "assertthat": "5.0.2"
+  }
+}

--- a/test/integration/test/runs-global-pre-and-post-tasks/test/integration/sampleTests.js
+++ b/test/integration/test/runs-global-pre-and-post-tasks/test/integration/sampleTests.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const { assert } = require('assertthat');
+
+suite('sample', () => {
+  test('does not fail.', done => {
+    /* eslint-disable no-console */
+    console.log('Hello from integration test!');
+    /* eslint-enable no-console */
+
+    assert.that(true).is.true();
+    done();
+  });
+});

--- a/test/integration/test/runs-global-pre-and-post-tasks/test/post.js
+++ b/test/integration/test/runs-global-pre-and-post-tasks/test/post.js
@@ -1,0 +1,5 @@
+'use strict';
+
+/* eslint-disable no-console */
+console.log('Hello from global post task!');
+/* eslint-enable no-console */

--- a/test/integration/test/runs-global-pre-and-post-tasks/test/pre.js
+++ b/test/integration/test/runs-global-pre-and-post-tasks/test/pre.js
@@ -1,0 +1,5 @@
+'use strict';
+
+/* eslint-disable no-console */
+console.log('Hello from global pre task!');
+/* eslint-enable no-console */

--- a/test/integration/test/runs-global-pre-and-post-tasks/test/unit/sampleTests.js
+++ b/test/integration/test/runs-global-pre-and-post-tasks/test/unit/sampleTests.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const { assert } = require('assertthat');
+
+suite('sample', () => {
+  test('does not fail.', done => {
+    /* eslint-disable no-console */
+    console.log('Hello from unit test!');
+    /* eslint-enable no-console */
+
+    assert.that(true).is.true();
+    done();
+  });
+});

--- a/test/integration/test/runs-post-task-on-crashing-tests/expected.js
+++ b/test/integration/test/runs-post-task-on-crashing-tests/expected.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const exitCode = 1;
+
+const stdout = [
+  `Hello from pre task!`,
+  `Hello from post task!`
+];
+
+const stderr = '✗ Tests failed.';
+
+module.exports = { exitCode, stdout, stderr };

--- a/test/integration/test/runs-post-task-on-crashing-tests/package.json
+++ b/test/integration/test/runs-post-task-on-crashing-tests/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-package",
+  "version": "0.0.1",
+  "devDependencies": {
+    "assertthat": "5.0.2"
+  }
+}

--- a/test/integration/test/runs-post-task-on-crashing-tests/test/unit/post.js
+++ b/test/integration/test/runs-post-task-on-crashing-tests/test/unit/post.js
@@ -1,0 +1,5 @@
+'use strict';
+
+/* eslint-disable no-console */
+console.log('Hello from post task!');
+/* eslint-enable no-console */

--- a/test/integration/test/runs-post-task-on-crashing-tests/test/unit/pre.js
+++ b/test/integration/test/runs-post-task-on-crashing-tests/test/unit/pre.js
@@ -1,0 +1,5 @@
+'use strict';
+
+/* eslint-disable no-console */
+console.log('Hello from pre task!');
+/* eslint-enable no-console */

--- a/test/integration/test/runs-post-task-on-crashing-tests/test/unit/sampleTests.js
+++ b/test/integration/test/runs-post-task-on-crashing-tests/test/unit/sampleTests.js
@@ -1,0 +1,9 @@
+'use strict';
+
+suite('sample', () => {
+  test('fails.', async () => {
+    /* eslint-disable unicorn/no-process-exit */
+    process.exit(1);
+    /* eslint-enable unicorn/no-process-exit */
+  });
+});


### PR DESCRIPTION
Hi @goloroden 

I've implemented pre- and post-hooks across test types. The files must be put directly in the `test` directory. There are multiple new tests that check the execution of these hooks and I added a new tests that the post hook (and also the individual post hooks for the test types) are even executed, when the test process crashes with exit code 1.

Please review it and feel free to merge it, if you think it is fine.

This will be a minor version bump.