### PR TITLE
fix: Use correct error constructor when non-strict dependencies are found.

### DIFF
--- a/lib/cli/tasks/dependencies.js
+++ b/lib/cli/tasks/dependencies.js
@@ -31,7 +31,7 @@ const dependenciesTask = async function ({ directory, ui }) {
       ui.warn('Non-strict dependencies found.');
       ui.table(nonStrictDependencies);
 
-      throw new errors.NonStrictDependenciesFound();
+      throw new errors.NonStrictDependencyFound();
     }
 
     ui.printTaskHeader('outdated dependencies check');

--- a/test/integration/deps/fails-on-non-strict-dependency/expected.js
+++ b/test/integration/deps/fails-on-non-strict-dependency/expected.js
@@ -2,7 +2,7 @@
 
 const exitCode = 1;
 
-const stdout = [
+const stdoutTest = [
   'Running strict dependencies check...',
   'Name   Version  Type',
   '─────  ───────  ────────────',
@@ -11,4 +11,10 @@ const stdout = [
 
 const stderr = 'Non-strict dependencies found.';
 
-module.exports = { exitCode, stdout, stderr };
+const validate = function ({ stdout }) {
+  if (stdout.includes('TypeError: errors.NonStrictDependenciesFound is not a constructor')) {
+    throw new Error('This bug should be fixed, see #464.');
+  }
+};
+
+module.exports = { exitCode, stdout: stdoutTest, stderr, validate };


### PR DESCRIPTION
This closes #464.
