### PR TITLE
feat: check license against SPDX license list

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The npm-package-json-lint analysis only affects the `package.json` file in the r
 
 To adjust the rules to be used, add an [`.npmpackagejsonlintrc.json`](https://npmpackagejsonlint.org/docs/en/rcfile-example) file to the root directory of your module or application. You may [extend](https://npmpackagejsonlint.org/docs/en/configuration#how-to-use-a-shared-config-module) the `npm-package-json-lint-config-tnw/app.json` configuration, the `npm-package-json-lint-config-tnw/lib.json` configuration or any configuration you have made yourself.
 
+In addition to the linting provided by [npm-package-json-lint](https://npmpackagejsonlint.org/), roboter checks the license provided
+by you against the [SPDX license list](https://github.com/spdx/license-list-XML). The default behavior is to reject licenses that are not present on the list, as well as deprecated licenses. If you wish to use a more exotic license that is not listed by SPDX, you may set `allowUnsupportedLicenseForThisPackage` to `true` in `licenseCheck.json`. Deprecated licenses can be enabled in a similar way by setting `allowDeprecatedLicenseForThisPackage` to `true` in `licenseCheck.json`.
+
 ## The `build` task
 
 If you want to use TypeScript, add the required `tsconfig.json` file to the root of your package to enable compilation on build.

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -41,6 +41,7 @@ class GitNotInUpdateableState extends defekt({ code: 'GitNotInUpdateableState' }
 class LicenseCheckConfigurationNotFound extends defekt({ code: 'LicenseCheckConfigurationNotFound' }) {}
 class LicenseCheckConfigurationMalformed extends defekt({ code: 'LicenseCheckConfigurationMalformed' }) {}
 class LicenseCheckFailed extends defekt({ code: 'LicenseCheckFailed' }) {}
+class LicenseDeprecated extends defekt({ code: 'LicenseDeprecated' }) {}
 class LicenseIncompatible extends defekt({ code: 'LicenseIncompatible' }) {}
 class LicenseNotFound extends defekt({ code: 'LicenseNotFound' }) {}
 class LicenseNotSupported extends defekt({ code: 'LicenseNotSupported' }) {}
@@ -85,6 +86,7 @@ export {
   LicenseCheckConfigurationNotFound,
   LicenseCheckConfigurationMalformed,
   LicenseCheckFailed,
+  LicenseDeprecated,
   LicenseIncompatible,
   LicenseNotFound,
   LicenseNotSupported,

--- a/lib/steps/analyze/checkLicenseExpression.ts
+++ b/lib/steps/analyze/checkLicenseExpression.ts
@@ -1,0 +1,41 @@
+import deprecatedSpdxLicenseIds from 'spdx-license-ids/deprecated.json';
+import { getLicense } from '../license/getLicense';
+import { getLicenseCheckConfiguration } from '../license/getLicenseCheckConfiguration';
+import { error, Result, value } from 'defekt';
+import * as errors from '../../errors';
+
+const checkLicenseExpression = async function ({
+  applicationRoot
+}: {
+  applicationRoot: string;
+}): Promise<Result<undefined, errors.LicenseNotFound | errors.LicenseNotSupported | errors.LicenseDeprecated>> {
+  const licenseCheckConfiguration = (await getLicenseCheckConfiguration({ absoluteDirectory: applicationRoot })).unwrapOrThrow();
+  const licenseResult = await getLicense({ absoluteDirectory: applicationRoot, licenseCheckConfiguration });
+
+  if (licenseResult.hasError()) {
+    if (licenseResult.error.code === errors.LicenseNotSupported.code && licenseCheckConfiguration.allowUnsupportedLicenseForThisPackage) {
+      return value();
+    }
+
+    return error(new errors.LicenseNotSupported({
+      message: `The given license is not supported, please check your spelling, or disable this check by setting 'allowUnsupportedLicenseForThisPackage
+      ' in licenseCheck.json.`,
+      cause: licenseResult.error
+    }));
+  }
+
+  const license = licenseResult.unwrapOrThrow();
+
+  if (deprecatedSpdxLicenseIds.includes(license) && !licenseCheckConfiguration.allowDeprecatedLicenseForThisPackage) {
+    return error(new errors.LicenseDeprecated({
+      message: `${license} is deprecated, please consider using an updated version of this license, or disable this check by setting 'allowDeprecatedLicenseForThisPackage
+      ' in licenseCheck.json.`
+    }));
+  }
+
+  return value();
+};
+
+export {
+  checkLicenseExpression
+};

--- a/lib/steps/analyze/checkLicenseExpression.ts
+++ b/lib/steps/analyze/checkLicenseExpression.ts
@@ -18,8 +18,7 @@ const checkLicenseExpression = async function ({
     }
 
     return error(new errors.LicenseNotSupported({
-      message: `The given license is not supported, please check your spelling, or disable this check by setting 'allowUnsupportedLicenseForThisPackage
-      ' in licenseCheck.json.`,
+      message: `The given license is not supported, please check your spelling, or disable this check by setting 'allowUnsupportedLicenseForThisPackage' in licenseCheck.json.`,
       cause: licenseResult.error
     }));
   }
@@ -28,8 +27,7 @@ const checkLicenseExpression = async function ({
 
   if (deprecatedSpdxLicenseIds.includes(license) && !licenseCheckConfiguration.allowDeprecatedLicenseForThisPackage) {
     return error(new errors.LicenseDeprecated({
-      message: `${license} is deprecated, please consider using an updated version of this license, or disable this check by setting 'allowDeprecatedLicenseForThisPackage
-      ' in licenseCheck.json.`
+      message: `${license} is deprecated, please consider using an updated version of this license, or disable this check by setting 'allowDeprecatedLicenseForThisPackage' in licenseCheck.json.`
     }));
   }
 

--- a/lib/steps/license/LicenseCheckConfiguration.ts
+++ b/lib/steps/license/LicenseCheckConfiguration.ts
@@ -1,6 +1,8 @@
 interface LicenseCheckConfiguration {
   compatibleLicenses: string[];
   knownPackageLicenses?: Record<string, Record<string, string>>;
+  allowUnsupportedLicenseForThisPackage?: boolean;
+  allowDeprecatedLicenseForThisPackage?: boolean;
 }
 
 export type {

--- a/lib/steps/license/parseLicenseCheckConfiguration.ts
+++ b/lib/steps/license/parseLicenseCheckConfiguration.ts
@@ -33,6 +33,12 @@ errors.LicenseCheckConfigurationMalformed
               }
             }
           }
+        },
+        allowUnsupportedLicenseForThisPackage: {
+          type: 'boolean'
+        },
+        allowDeprecatedLicenseForThisPackage: {
+          type: 'boolean'
         }
       },
       required: [ 'compatibleLicenses' ],

--- a/lib/tasks/analyzeTask.ts
+++ b/lib/tasks/analyzeTask.ts
@@ -1,4 +1,5 @@
 import { buntstift } from 'buntstift';
+import { checkLicenseExpression } from '../steps/analyze/checkLicenseExpression';
 import { lintCode } from '../steps/analyze/lintCode';
 import { lintPackageJson } from '../steps/analyze/lintPackageJson';
 import { error, Result, value } from 'defekt';
@@ -29,6 +30,34 @@ const analyzeTask = async function ({ applicationRoot }: {
         throw lintPackageJsonResult.error;
       }
     }
+  }
+
+  stopWaiting = buntstift.wait();
+
+  const checkLicenseExpressionResult = await checkLicenseExpression({ applicationRoot });
+
+  stopWaiting();
+
+  if (checkLicenseExpressionResult.hasError()) {
+    buntstift.raw(`${checkLicenseExpressionResult.error.message}\n`);
+
+    // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check, default-case
+    switch (checkLicenseExpressionResult.error.code) {
+      case errors.LicenseNotFound.code: {
+        buntstift.error('No license was found for this package.');
+        break;
+      }
+      case errors.LicenseNotSupported.code: {
+        buntstift.error('The given license is not a valid SPDX expression.');
+        break;
+      }
+      case errors.LicenseDeprecated.code: {
+        buntstift.error('The given license is deprecated.');
+        break;
+      }
+    }
+
+    return error(new errors.AnalysisFailed());
   }
 
   stopWaiting = buntstift.wait();

--- a/lib/tasks/analyzeTask.ts
+++ b/lib/tasks/analyzeTask.ts
@@ -39,20 +39,21 @@ const analyzeTask = async function ({ applicationRoot }: {
   stopWaiting();
 
   if (checkLicenseExpressionResult.hasError()) {
-    buntstift.raw(`${checkLicenseExpressionResult.error.message}\n`);
-
     // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check, default-case
     switch (checkLicenseExpressionResult.error.code) {
       case errors.LicenseNotFound.code: {
         buntstift.error('No license was found for this package.');
+        buntstift.raw(`${checkLicenseExpressionResult.error.message}\n`);
         break;
       }
       case errors.LicenseNotSupported.code: {
         buntstift.error('The given license is not a valid SPDX expression.');
+        buntstift.raw(`${checkLicenseExpressionResult.error.message}\n`);
         break;
       }
       case errors.LicenseDeprecated.code: {
         buntstift.error('The given license is deprecated.');
+        buntstift.raw(`${checkLicenseExpressionResult.error.message}\n`);
         break;
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "roboter",
       "version": "12.1.3",
       "license": "MIT",
       "dependencies": {
@@ -36,7 +37,7 @@
         "nodeenv": "3.0.71",
         "normalize-path": "3.0.0",
         "npm-package-json-lint": "5.2.3",
-        "npm-package-json-lint-config-tnw": "1.1.1",
+        "npm-package-json-lint-config-tnw": "1.1.2",
         "processenv": "3.0.8",
         "semver": "7.3.5",
         "shelljs": "0.8.4",
@@ -5752,9 +5753,9 @@
       }
     },
     "node_modules/npm-package-json-lint-config-tnw": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/npm-package-json-lint-config-tnw/-/npm-package-json-lint-config-tnw-1.1.1.tgz",
-      "integrity": "sha512-mbZdNm2N6FeZCNP8q3I4ymXBBR0/mihsVWX10UevlZb3ylu90PXGw2SGbwhOMG/YKXsUKDzVedWdXlxnYCQxYQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/npm-package-json-lint-config-tnw/-/npm-package-json-lint-config-tnw-1.1.2.tgz",
+      "integrity": "sha512-ou0rfT/2vlOySjh4rSSsOGeqV63YEfXmYWfm1fdwUUvUJ8RD6TNSf/9DGk6AcGST2nOnTOpC5q63e4MPRSzGRw==",
       "engines": {
         "node": ">=16.2.0"
       }
@@ -17478,9 +17479,9 @@
       }
     },
     "npm-package-json-lint-config-tnw": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/npm-package-json-lint-config-tnw/-/npm-package-json-lint-config-tnw-1.1.1.tgz",
-      "integrity": "sha512-mbZdNm2N6FeZCNP8q3I4ymXBBR0/mihsVWX10UevlZb3ylu90PXGw2SGbwhOMG/YKXsUKDzVedWdXlxnYCQxYQ=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/npm-package-json-lint-config-tnw/-/npm-package-json-lint-config-tnw-1.1.2.tgz",
+      "integrity": "sha512-ou0rfT/2vlOySjh4rSSsOGeqV63YEfXmYWfm1fdwUUvUJ8RD6TNSf/9DGk6AcGST2nOnTOpC5q63e4MPRSzGRw=="
     },
     "npm-run-path": {
       "version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "semver": "7.3.5",
         "shelljs": "0.8.4",
         "spdx-expression-parse": "3.0.1",
+        "spdx-license-ids": "3.0.10",
         "spdx-satisfies": "5.0.1",
         "ts-node": "10.2.1",
         "type-fest": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "semver": "7.3.5",
     "shelljs": "0.8.4",
     "spdx-expression-parse": "3.0.1",
+    "spdx-license-ids": "3.0.10",
     "spdx-satisfies": "5.0.1",
     "ts-node": "10.2.1",
     "type-fest": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "nodeenv": "3.0.71",
     "normalize-path": "3.0.0",
     "npm-package-json-lint": "5.2.3",
-    "npm-package-json-lint-config-tnw": "1.1.1",
+    "npm-package-json-lint-config-tnw": "1.1.2",
     "processenv": "3.0.8",
     "semver": "7.3.5",
     "shelljs": "0.8.4",

--- a/test/integration/analyzeTests.ts
+++ b/test/integration/analyzeTests.ts
@@ -265,4 +265,78 @@ suite('analyze', function (): void {
       assert.that(stripAnsi(error.stderr)).is.containing('Malformed package.json found.');
     }
   );
+
+  testWithFixture(
+    'fails with deprecated package license.',
+    [ 'analyze', 'with-deprecated-license' ],
+    async (fixture): Promise<void> => {
+      const roboterResult = await runCommand('npx roboter analyze', {
+        cwd: fixture.absoluteTestDirectory,
+        silent: true
+      });
+
+      if (roboterResult.hasValue()) {
+        throw new Error(`The command should have failed, but didn't.`);
+      }
+
+      const { error } = roboterResult;
+
+      assert.that(error.exitCode).is.equalTo(1);
+      assert.that(stripAnsi(error.stdout)).is.containing(stripIndent`
+        HERE BE ERRORS
+      `);
+      assert.that(stripAnsi(error.stderr)).is.containing('Malformed package.json found.');
+    }
+  );
+
+  testWithFixture(
+    'fails with unsupported package license.',
+    [ 'analyze', 'with-unsupported-license' ],
+    async (fixture): Promise<void> => {
+      const roboterResult = await runCommand('npx roboter analyze', {
+        cwd: fixture.absoluteTestDirectory,
+        silent: true
+      });
+
+      if (roboterResult.hasValue()) {
+        throw new Error(`The command should have failed, but didn't.`);
+      }
+
+      const { error } = roboterResult;
+
+      assert.that(error.exitCode).is.equalTo(1);
+      assert.that(stripAnsi(error.stdout)).is.containing(stripIndent`
+        HERE BE ERRORS
+      `);
+      assert.that(stripAnsi(error.stderr)).is.containing('Malformed package.json found.');
+    }
+  );
+
+  testWithFixture(
+    'succeeds with deprecated package license and allowDeprecatedLicenseForThisPackage set to true.',
+    [ 'analyze', 'with-deprecated-license-with-exception' ],
+    async (fixture): Promise<void> => {
+      const roboterResult = await runCommand('npx roboter analyze', {
+        cwd: fixture.absoluteTestDirectory,
+        silent: true
+      });
+
+      assert.that(roboterResult).is.aValue();
+      assert.that(roboterResult.unwrapOrThrow().exitCode).is.equalTo(0);
+    }
+  );
+
+  testWithFixture(
+    'succeeds with unsupported package license and allowUnsupportedLicenseForThisPackage set to true.',
+    [ 'analyze', 'with-unsupported-license-with-exception' ],
+    async (fixture): Promise<void> => {
+      const roboterResult = await runCommand('npx roboter analyze', {
+        cwd: fixture.absoluteTestDirectory,
+        silent: true
+      });
+
+      assert.that(roboterResult).is.aValue();
+      assert.that(roboterResult.unwrapOrThrow().exitCode).is.equalTo(0);
+    }
+  );
 });

--- a/test/integration/analyzeTests.ts
+++ b/test/integration/analyzeTests.ts
@@ -283,9 +283,9 @@ suite('analyze', function (): void {
 
       assert.that(error.exitCode).is.equalTo(1);
       assert.that(stripAnsi(error.stdout)).is.containing(stripIndent`
-        HERE BE ERRORS
+        GPL-2.0 is deprecated, please consider using an updated version of this license
       `);
-      assert.that(stripAnsi(error.stderr)).is.containing('Malformed package.json found.');
+      assert.that(stripAnsi(error.stderr)).is.containing('The given license is deprecated.');
     }
   );
 
@@ -306,9 +306,9 @@ suite('analyze', function (): void {
 
       assert.that(error.exitCode).is.equalTo(1);
       assert.that(stripAnsi(error.stdout)).is.containing(stripIndent`
-        HERE BE ERRORS
+        The given license is not supported, please check your spelling
       `);
-      assert.that(stripAnsi(error.stderr)).is.containing('Malformed package.json found.');
+      assert.that(stripAnsi(error.stderr)).is.containing('The given license is not a valid SPDX expression.');
     }
   );
 

--- a/test/shared/fixtures/analyze/with-custom-eslintrc/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-custom-eslintrc/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/analyze/with-deprecated-license-with-exception/app.js
+++ b/test/shared/fixtures/analyze/with-deprecated-license-with-exception/app.js
@@ -1,3 +1,4 @@
 'use strict';
 
+// eslint-disable-next-line no-unused-vars
 const x = 42;

--- a/test/shared/fixtures/analyze/with-deprecated-license-with-exception/app.js
+++ b/test/shared/fixtures/analyze/with-deprecated-license-with-exception/app.js
@@ -1,0 +1,3 @@
+'use strict';
+
+const x = 42;

--- a/test/shared/fixtures/analyze/with-deprecated-license-with-exception/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-deprecated-license-with-exception/licenseCheck.json
@@ -1,0 +1,15 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ],
+  "allowDeprecatedLicenseForThisPackage": true
+}

--- a/test/shared/fixtures/analyze/with-deprecated-license-with-exception/package.json
+++ b/test/shared/fixtures/analyze/with-deprecated-license-with-exception/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-package",
+  "version": "0.0.1",
+  "description": "a test-package.",
+  "contributors": [],
+  "private": false,
+  "main": "",
+  "types": "",
+  "engines": {},
+  "dependencies": {},
+  "devDependencies": {},
+  "scripts": {},
+  "repository": {},
+  "keywords": [],
+  "license": "GPL-2.0"
+}

--- a/test/shared/fixtures/analyze/with-deprecated-license/app.js
+++ b/test/shared/fixtures/analyze/with-deprecated-license/app.js
@@ -1,3 +1,4 @@
 'use strict';
 
+// eslint-disable-next-line no-unused-vars
 const x = 42;

--- a/test/shared/fixtures/analyze/with-deprecated-license/app.js
+++ b/test/shared/fixtures/analyze/with-deprecated-license/app.js
@@ -1,0 +1,3 @@
+'use strict';
+
+const x = 42;

--- a/test/shared/fixtures/analyze/with-deprecated-license/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-deprecated-license/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/analyze/with-deprecated-license/package.json
+++ b/test/shared/fixtures/analyze/with-deprecated-license/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-package",
+  "version": "0.0.1",
+  "description": "a test-package.",
+  "contributors": [],
+  "private": false,
+  "main": "",
+  "types": "",
+  "engines": {},
+  "dependencies": {},
+  "devDependencies": {},
+  "scripts": {},
+  "repository": {},
+  "keywords": [],
+  "license": "GPL-2.0"
+}

--- a/test/shared/fixtures/analyze/with-eslint-errors-in-mocha-tests/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-eslint-errors-in-mocha-tests/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/analyze/with-eslint-errors-in-nested-node-module/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-eslint-errors-in-nested-node-module/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/analyze/with-eslint-errors-in-top-level-node-module/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-eslint-errors-in-top-level-node-module/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/analyze/with-eslint-errors-in-typescript/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-eslint-errors-in-typescript/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/analyze/with-eslint-errors/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-eslint-errors/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/analyze/with-eslintignore/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-eslintignore/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/analyze/with-invalid-package.json-and-custom-npmpackagejsonlintrc/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-invalid-package.json-and-custom-npmpackagejsonlintrc/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/analyze/with-invalid-package.json/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-invalid-package.json/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/analyze/with-nested-eslint-configuration/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-nested-eslint-configuration/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/analyze/with-preanalyze-and-postanalyze-task/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-preanalyze-and-postanalyze-task/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/analyze/with-unsupported-license-with-exception/app.js
+++ b/test/shared/fixtures/analyze/with-unsupported-license-with-exception/app.js
@@ -1,3 +1,4 @@
 'use strict';
 
+// eslint-disable-next-line no-unused-vars
 const x = 42;

--- a/test/shared/fixtures/analyze/with-unsupported-license-with-exception/app.js
+++ b/test/shared/fixtures/analyze/with-unsupported-license-with-exception/app.js
@@ -1,0 +1,3 @@
+'use strict';
+
+const x = 42;

--- a/test/shared/fixtures/analyze/with-unsupported-license-with-exception/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-unsupported-license-with-exception/licenseCheck.json
@@ -1,0 +1,15 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ],
+  "allowUnsupportedLicenseForThisPackage": true
+}

--- a/test/shared/fixtures/analyze/with-unsupported-license-with-exception/package.json
+++ b/test/shared/fixtures/analyze/with-unsupported-license-with-exception/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-package",
+  "version": "0.0.1",
+  "description": "a test-package.",
+  "contributors": [],
+  "private": false,
+  "main": "",
+  "types": "",
+  "engines": {},
+  "dependencies": {},
+  "devDependencies": {},
+  "scripts": {},
+  "repository": {},
+  "keywords": [],
+  "license": "BLNKLGHTS-1.33.7"
+}

--- a/test/shared/fixtures/analyze/with-unsupported-license/app.js
+++ b/test/shared/fixtures/analyze/with-unsupported-license/app.js
@@ -1,3 +1,4 @@
 'use strict';
 
+// eslint-disable-next-line no-unused-vars
 const x = 42;

--- a/test/shared/fixtures/analyze/with-unsupported-license/app.js
+++ b/test/shared/fixtures/analyze/with-unsupported-license/app.js
@@ -1,0 +1,3 @@
+'use strict';
+
+const x = 42;

--- a/test/shared/fixtures/analyze/with-unsupported-license/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-unsupported-license/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/analyze/with-unsupported-license/package.json
+++ b/test/shared/fixtures/analyze/with-unsupported-license/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-package",
+  "version": "0.0.1",
+  "description": "a test-package.",
+  "contributors": [],
+  "private": false,
+  "main": "",
+  "types": "",
+  "engines": {},
+  "dependencies": {},
+  "devDependencies": {},
+  "scripts": {},
+  "repository": {},
+  "keywords": [],
+  "license": "BLNKLGHTS-1.33.7"
+}

--- a/test/shared/fixtures/analyze/with-valid-jsx/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-valid-jsx/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/build/with-invalid-typescript/licenseCheck.json
+++ b/test/shared/fixtures/build/with-invalid-typescript/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/build/with-prebuild-and-postbuild-task/licenseCheck.json
+++ b/test/shared/fixtures/build/with-prebuild-and-postbuild-task/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/build/with-tsconfig-incremental-flag-true/licenseCheck.json
+++ b/test/shared/fixtures/build/with-tsconfig-incremental-flag-true/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/build/with-typescript-feature-that-requires-newer-version/licenseCheck.json
+++ b/test/shared/fixtures/build/with-typescript-feature-that-requires-newer-version/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/deps/with-non-strict-dependency/licenseCheck.json
+++ b/test/shared/fixtures/deps/with-non-strict-dependency/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/deps/with-non-strict-dev-dependency/licenseCheck.json
+++ b/test/shared/fixtures/deps/with-non-strict-dev-dependency/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/deps/with-outdated-dependency/licenseCheck.json
+++ b/test/shared/fixtures/deps/with-outdated-dependency/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/deps/with-predeps-and-postdeps-task/licenseCheck.json
+++ b/test/shared/fixtures/deps/with-predeps-and-postdeps-task/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/deps/with-unused-dependency-in-tsx/licenseCheck.json
+++ b/test/shared/fixtures/deps/with-unused-dependency-in-tsx/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/deps/with-unused-dependency/licenseCheck.json
+++ b/test/shared/fixtures/deps/with-unused-dependency/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/deps/with-up-to-date-dependencies-in-tsx/licenseCheck.json
+++ b/test/shared/fixtures/deps/with-up-to-date-dependencies-in-tsx/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/deps/with-up-to-date-dependencies-in-typescript/licenseCheck.json
+++ b/test/shared/fixtures/deps/with-up-to-date-dependencies-in-typescript/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/deps/with-up-to-date-dependencies/licenseCheck.json
+++ b/test/shared/fixtures/deps/with-up-to-date-dependencies/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/test/with-.env-file/licenseCheck.json
+++ b/test/shared/fixtures/test/with-.env-file/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/test/with-failing-unit-test/licenseCheck.json
+++ b/test/shared/fixtures/test/with-failing-unit-test/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/test/with-library-under-test/licenseCheck.json
+++ b/test/shared/fixtures/test/with-library-under-test/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/test/with-mocharc-js-configuration-file/licenseCheck.json
+++ b/test/shared/fixtures/test/with-mocharc-js-configuration-file/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/test/with-mocharc-json-configuration-file/licenseCheck.json
+++ b/test/shared/fixtures/test/with-mocharc-json-configuration-file/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/test/with-pre-and-post-scripts/licenseCheck.json
+++ b/test/shared/fixtures/test/with-pre-and-post-scripts/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/test/with-pretest-and-posttest-task/licenseCheck.json
+++ b/test/shared/fixtures/test/with-pretest-and-posttest-task/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/test/with-tests-in-shared/licenseCheck.json
+++ b/test/shared/fixtures/test/with-tests-in-shared/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/test/with-tsx-tests/licenseCheck.json
+++ b/test/shared/fixtures/test/with-tsx-tests/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/with-valid-javascript/licenseCheck.json
+++ b/test/shared/fixtures/with-valid-javascript/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/with-valid-typescript/licenseCheck.json
+++ b/test/shared/fixtures/with-valid-typescript/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}


### PR DESCRIPTION
This change adds validation of the package's license against the SPDX license list. Previously, we enforced a list of allowed license IDs that is defined by https://github.com/thenativeweb/npm-package-json-lint-config-tnw. This has proven unpractical, as many license may be used and we can't provide useful defaults for everyone. We decided against enforcing a specific set of licenses and are instead focusing on SPDX now. This is mainly to guard against typos and deprecation. The roboter will now check the package's license against the list of SPDX license IDs during its `qa` step. The default behavior is to reject non-SPDX licenses, as well as deprecated licenses. Both can be disabled on a per-project basis using the `licenseCheck.json` configuration file.