### PR TITLE
fix: roll back typescript 4.4 update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "roboter",
       "version": "12.2.3",
       "license": "MIT",
       "dependencies": {
@@ -46,7 +45,7 @@
         "spdx-satisfies": "5.0.1",
         "ts-node": "10.2.1",
         "type-fest": "2.1.0",
-        "typescript": "4.4.2",
+        "typescript": "4.3.5",
         "validate-value": "9.1.6",
         "walk-file-tree": "1.0.31"
       },
@@ -8418,11 +8417,6 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10895,9 +10889,9 @@
       "integrity": "sha512-4spUugjxcZTlQaHuKQWVtI+DJx1Pp+zjCD+/0vpMPjNnliowHCEYsVm4sbyzgspuB7Y8djKN/J6V+7phrCVXUQ=="
     },
     "node_modules/typescript": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
-      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19358,9 +19352,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
-      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ=="
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA=="
     },
     "typical": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "spdx-satisfies": "5.0.1",
     "ts-node": "10.2.1",
     "type-fest": "2.1.0",
-    "typescript": "4.4.2",
+    "typescript": "4.3.5",
     "validate-value": "9.1.6",
     "walk-file-tree": "1.0.31"
   },


### PR DESCRIPTION
Some breaking changes are being introduced bei TypeScript 4.4, mainly regarding libdom. Some of the types we use from DefinitelyTyped seem to be incompatible with these changes, hence we might want to delay the update until these issues have been addressed.  Of course, there's the question of how we'd identify all affected dependencies and determine their compatibility. Just updating and seeing what breaks might be a viable strategy, too.
Nevertheless, updating TypeScript might warrant a major release, as it breaks existing builds. We should discuss this in more detail and decide on a course of action. At the moment, we should roll back the update to perform a more deliberate release in the future.