### PR TITLE
fix: perform type check during `qa` command

### DIFF
--- a/lib/steps/analyze/typeCheckCode.ts
+++ b/lib/steps/analyze/typeCheckCode.ts
@@ -1,0 +1,18 @@
+import { compileTypeScript } from '../build/compileTypeScript';
+import { Result } from 'defekt';
+import * as errors from '../../errors';
+
+const typeCheckCode = async function ({
+  applicationRoot
+}: {
+  applicationRoot: string;
+}): Promise<Result<
+  undefined,
+  errors.TypeScriptOutputConfigurationMissing | errors.TypeScriptCompilationFailed
+  >> {
+  return compileTypeScript({ applicationRoot, noEmit: true });
+};
+
+export {
+  typeCheckCode
+};

--- a/test/integration/analyzeTests.ts
+++ b/test/integration/analyzeTests.ts
@@ -290,6 +290,25 @@ suite('analyze', function (): void {
   );
 
   testWithFixture(
+    'fails with type errors',
+    [ 'analyze', 'with-type-errors' ],
+    async (fixture): Promise<void> => {
+      const roboterResult = await runCommand('npx roboter analyze', {
+        cwd: fixture.absoluteTestDirectory,
+        silent: true
+      });
+
+      if (roboterResult.hasValue()) {
+        throw new Error(`The command should have failed, but didn't.`);
+      }
+
+      const { error } = roboterResult;
+
+      assert.that(error.exitCode).is.equalTo(1);
+    }
+  );
+
+  testWithFixture(
     'fails with unsupported package license.',
     [ 'analyze', 'with-unsupported-license' ],
     async (fixture): Promise<void> => {

--- a/test/shared/fixtures/analyze/with-type-errors/.eslintrc.json
+++ b/test/shared/fixtures/analyze/with-type-errors/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "es/node"
+}

--- a/test/shared/fixtures/analyze/with-type-errors/.npmpackagejsonlintrc.json
+++ b/test/shared/fixtures/analyze/with-type-errors/.npmpackagejsonlintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "npm-package-json-lint-config-tnw/lib.json",
+  "rules": {
+    "prefer-alphabetical-devDependencies": "off"
+  }
+}

--- a/test/shared/fixtures/analyze/with-type-errors/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-type-errors/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/analyze/with-type-errors/package.json
+++ b/test/shared/fixtures/analyze/with-type-errors/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "test-package",
+  "version": "0.0.1",
+  "description": "a test-package.",
+  "contributors": [],
+  "private": false,
+  "main": "",
+  "types": "",
+  "engines": {},
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "12.12.14",
+    "assertthat": "5.0.2"
+  },
+  "scripts": {},
+  "repository": {},
+  "keywords": [],
+  "license": "MIT"
+}

--- a/test/shared/fixtures/analyze/with-type-errors/src/index.ts
+++ b/test/shared/fixtures/analyze/with-type-errors/src/index.ts
@@ -4,7 +4,7 @@ const add = function (left: number, right: number): number {
 
 const sum = add(23, 42);
 
-const schmarrn = add('left', 'right');
+const incorrect = add('left', 'right');
 
 // eslint-disable-next-line no-console
-console.log(sum, schmarrn);
+console.log(sum, incorrect);

--- a/test/shared/fixtures/analyze/with-type-errors/src/index.ts
+++ b/test/shared/fixtures/analyze/with-type-errors/src/index.ts
@@ -1,0 +1,10 @@
+const add = function (left: number, right: number): number {
+  return left + right;
+};
+
+const sum = add(23, 42);
+
+const schmarrn = add('left', 'right');
+
+// eslint-disable-next-line no-console
+console.log(sum, schmarrn);

--- a/test/shared/fixtures/analyze/with-type-errors/test/integration/someIntegrationTests.ts
+++ b/test/shared/fixtures/analyze/with-type-errors/test/integration/someIntegrationTests.ts
@@ -1,0 +1,7 @@
+import { assert } from 'assertthat';
+
+suite('someIntegration', (): void => {
+  test('test something.', async (): Promise<void> => {
+    assert.that(true).is.true();
+  });
+});

--- a/test/shared/fixtures/analyze/with-type-errors/test/unit/someUnitTests.ts
+++ b/test/shared/fixtures/analyze/with-type-errors/test/unit/someUnitTests.ts
@@ -1,0 +1,7 @@
+import { assert } from 'assertthat';
+
+suite('someUnit', (): void => {
+  test('test something.', async (): Promise<void> => {
+    assert.that(true).is.true();
+  });
+});

--- a/test/shared/fixtures/analyze/with-type-errors/tsconfig.json
+++ b/test/shared/fixtures/analyze/with-type-errors/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "declaration": true,
+    "esModuleInterop": true,
+    "lib": [ "dom", "esnext" ],
+    "module": "commonjs",
+    "outDir": "build",
+    "resolveJsonModule": true,
+    "strict": true,
+    "target": "es2019"
+  },
+  "include": [
+    "./**/*.ts"
+  ]
+}


### PR DESCRIPTION
The roboter has many commands, the default command is `qa`. This command is used in CI and locally as the standard way to perform quality assurance. It _should_ identify all problems that can be found by static analysis and report them.

The current version does not build Typescript during the `qa` command, causing type errors to be unreported. This PR adds type checking using the TypeScript compiler to the `qa` command. No code is generated during this phase.