### PR TITLE
feat: Make license check configuration optional for analyze command.

### DIFF
--- a/lib/steps/license/getLicense.ts
+++ b/lib/steps/license/getLicense.ts
@@ -8,7 +8,7 @@ import * as errors from '../../errors';
 
 const getLicense = async function ({ absoluteDirectory, licenseCheckConfiguration }: {
   absoluteDirectory: string;
-  licenseCheckConfiguration: LicenseCheckConfiguration;
+  licenseCheckConfiguration?: LicenseCheckConfiguration;
 }): Promise<Result<string, errors.LicenseNotFound | errors.LicenseNotSupported>> {
   const packageJsonResult = await getPackageJson({ absoluteDirectory });
 
@@ -58,11 +58,13 @@ const getLicense = async function ({ absoluteDirectory, licenseCheckConfiguratio
 
   let knownPackageLicense: string | undefined;
 
-  knownPackageLicense = getMatchingLicense({
-    licensesMap: licenseCheckConfiguration.knownPackageLicenses ?? {},
-    packageName,
-    packageVersion
-  });
+  if (licenseCheckConfiguration) {
+    knownPackageLicense = getMatchingLicense({
+      licensesMap: licenseCheckConfiguration.knownPackageLicenses ?? {},
+      packageName,
+      packageVersion
+    });
+  }
   if (!knownPackageLicense) {
     knownPackageLicense = getMatchingLicense({
       licensesMap: packageLicenses,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "roboter",
       "version": "12.2.5",
       "license": "MIT",
       "dependencies": {
@@ -8417,11 +8416,6 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"

--- a/test/integration/analyzeTests.ts
+++ b/test/integration/analyzeTests.ts
@@ -358,4 +358,27 @@ suite('analyze', function (): void {
       assert.that(roboterResult.unwrapOrThrow().exitCode).is.equalTo(0);
     }
   );
+
+  testWithFixture(
+    'validates license strictly if no license check configuration exists.',
+    [ 'analyze', 'without-license-check-configuration' ],
+    async (fixture): Promise<void> => {
+      const roboterResult = await runCommand('npx roboter analyze', {
+        cwd: fixture.absoluteTestDirectory,
+        silent: true
+      });
+
+      if (roboterResult.hasValue()) {
+        throw new Error(`The command should have failed, but didn't.`);
+      }
+
+      const { error } = roboterResult;
+
+      assert.that(error.exitCode).is.equalTo(1);
+      assert.that(stripAnsi(error.stdout)).is.containing(stripIndent`
+        The given license is not supported, please check your spelling
+      `);
+      assert.that(stripAnsi(error.stderr)).is.containing('The given license is not a valid SPDX expression.');
+    }
+  );
 });

--- a/test/shared/fixtures/analyze/without-license-check-configuration/app.js
+++ b/test/shared/fixtures/analyze/without-license-check-configuration/app.js
@@ -1,0 +1,4 @@
+'use strict';
+
+// eslint-disable-next-line no-unused-vars
+const x = 42;

--- a/test/shared/fixtures/analyze/without-license-check-configuration/package.json
+++ b/test/shared/fixtures/analyze/without-license-check-configuration/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-package",
+  "version": "0.0.1",
+  "description": "a test-package.",
+  "contributors": [],
+  "private": false,
+  "main": "",
+  "types": "",
+  "engines": {},
+  "dependencies": {},
+  "devDependencies": {},
+  "scripts": {},
+  "repository": {},
+  "keywords": [],
+  "license": "BLNKLGHTS-1.33.7"
+}


### PR DESCRIPTION
Without a license check configuration the most strict analysis of the
license is performed.

Closes #711.
