### PR TITLE
fix: Analyze succeeds even if ts output config is missing.

### DIFF
--- a/lib/steps/build/compileTypeScript.ts
+++ b/lib/steps/build/compileTypeScript.ts
@@ -24,7 +24,7 @@ const compileTypeScript = async function ({
   const parsedTsConfig = ts.parseJsonSourceFileConfigFileContent(tsConfigSourceFile, ts.sys, applicationRoot, undefined, tsConfigPath);
   const compilerOptions = parsedTsConfig.options;
 
-  if (!compilerOptions.outDir) {
+  if (!compilerOptions.outDir && !noEmit) {
     return error(new errors.TypeScriptOutputConfigurationMissing());
   }
 
@@ -45,8 +45,8 @@ const compileTypeScript = async function ({
     options: compilerOptions
   });
 
-  if (compilerOptions.incremental !== true) {
-    await fs.promises.rm(compilerOptions.outDir, { recursive: true, force: true });
+  if (compilerOptions.incremental !== true && !noEmit) {
+    await fs.promises.rm(compilerOptions.outDir!, { recursive: true, force: true });
   }
 
   let emitResult: EmitResult | undefined;

--- a/test/integration/analyzeTests.ts
+++ b/test/integration/analyzeTests.ts
@@ -381,4 +381,18 @@ suite('analyze', function (): void {
       assert.that(stripAnsi(error.stderr)).is.containing('The given license is not a valid SPDX expression.');
     }
   );
+
+  testWithFixture(
+    'does not fail when outDir is not configured in tsconfig',
+    [ 'analyze', 'without-output-config' ],
+    async (fixture): Promise<void> => {
+      const roboterResult = await runCommand('npx roboter analyze', {
+        cwd: fixture.absoluteTestDirectory,
+        silent: true
+      });
+
+      assert.that(roboterResult).is.aValue();
+      assert.that(roboterResult.unwrapOrThrow().exitCode).is.equalTo(0);
+    }
+  );
 });

--- a/test/shared/fixtures/analyze/without-output-config/.eslintrc.json
+++ b/test/shared/fixtures/analyze/without-output-config/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "es/node"
+}

--- a/test/shared/fixtures/analyze/without-output-config/.npmpackagejsonlintrc.json
+++ b/test/shared/fixtures/analyze/without-output-config/.npmpackagejsonlintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "npm-package-json-lint-config-tnw/lib.json",
+  "rules": {
+    "prefer-alphabetical-devDependencies": "off"
+  }
+}

--- a/test/shared/fixtures/analyze/without-output-config/licenseCheck.json
+++ b/test/shared/fixtures/analyze/without-output-config/licenseCheck.json
@@ -1,0 +1,14 @@
+{
+  "compatibleLicenses": [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "MIT",
+    "ISC",
+    "Python-2.0"
+  ]
+}

--- a/test/shared/fixtures/analyze/without-output-config/package.json
+++ b/test/shared/fixtures/analyze/without-output-config/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-package",
+  "version": "0.0.1",
+  "description": "a test-package.",
+  "contributors": [],
+  "private": false,
+  "main": "",
+  "types": "",
+  "engines": {},
+  "dependencies": {},
+  "devDependencies": {},
+  "scripts": {},
+  "repository": {},
+  "keywords": [],
+  "license": "MIT"
+}

--- a/test/shared/fixtures/analyze/without-output-config/src/index.ts
+++ b/test/shared/fixtures/analyze/without-output-config/src/index.ts
@@ -1,0 +1,8 @@
+const add = function (left: number, right: number): number {
+  return left + right;
+};
+
+const sum = add(23, 42);
+
+// eslint-disable-next-line no-console
+console.log(sum);

--- a/test/shared/fixtures/analyze/without-output-config/tsconfig.json
+++ b/test/shared/fixtures/analyze/without-output-config/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "declaration": true,
+    "esModuleInterop": true,
+    "lib": [ "dom", "esnext" ],
+    "module": "commonjs",
+    "resolveJsonModule": true,
+    "strict": true,
+    "target": "es2019"
+  },
+  "include": [
+    "./**/*.ts"
+  ]
+}


### PR DESCRIPTION
Since the analysis does not need to emit code, the output configuration
is irrelevant and can be ignored.

This resolves #787.