### PR TITLE
feat: Make license list optional.

### DIFF
--- a/lib/steps/license/LicenseCheckConfiguration.ts
+++ b/lib/steps/license/LicenseCheckConfiguration.ts
@@ -1,5 +1,5 @@
 interface LicenseCheckConfiguration {
-  compatibleLicenses: string[];
+  compatibleLicenses?: string[];
   knownPackageLicenses?: Record<string, Record<string, string>>;
   allowUnsupportedLicenseForThisPackage?: boolean;
   allowDeprecatedLicenseForThisPackage?: boolean;

--- a/lib/steps/license/findIncompatiblePackages.ts
+++ b/lib/steps/license/findIncompatiblePackages.ts
@@ -60,7 +60,7 @@ const findIncompatiblePackages = async function ({
     const packageLicense = getLicenseResult.value;
     const packageVersion = packageJson.version!;
 
-    if (licenseCheckConfiguration.compatibleLicenses.some((license): boolean => satisfies(license, packageLicense))) {
+    if (licenseCheckConfiguration.compatibleLicenses!.some((license): boolean => satisfies(license, packageLicense))) {
       continue;
     }
 

--- a/lib/steps/license/parseLicenseCheckConfiguration.ts
+++ b/lib/steps/license/parseLicenseCheckConfiguration.ts
@@ -41,7 +41,7 @@ errors.LicenseCheckConfigurationMalformed
           type: 'boolean'
         }
       },
-      required: [ 'compatibleLicenses' ],
+      required: [],
       additionalProperties: false
     },
     { valueName: 'licenseCheckConfiguration' }

--- a/lib/tasks/checkLicenseCompatibilityTask.ts
+++ b/lib/tasks/checkLicenseCompatibilityTask.ts
@@ -36,6 +36,12 @@ const checkLicenseCompatibilityTask = async function ({ applicationRoot }: {
 
   const licenseCheckConfiguration = licenseCheckConfigurationResult.value;
 
+  if (licenseCheckConfiguration.compatibleLicenses === undefined) {
+    buntstift.warn('No list of compatible licenses found. Skipping license compatibility check...');
+
+    return value();
+  }
+
   const incompatiblePackages = await findIncompatiblePackages({
     licenseCheckConfiguration,
     absoluteDirectory: applicationRoot

--- a/test/shared/fixtures/analyze/with-unsupported-license-with-exception/licenseCheck.json
+++ b/test/shared/fixtures/analyze/with-unsupported-license-with-exception/licenseCheck.json
@@ -1,15 +1,3 @@
 {
-  "compatibleLicenses": [
-    "0BSD",
-    "Apache-2.0",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "CC-BY-3.0",
-    "CC-BY-4.0",
-    "CC0-1.0",
-    "MIT",
-    "ISC",
-    "Python-2.0"
-  ],
   "allowUnsupportedLicenseForThisPackage": true
 }


### PR DESCRIPTION
This allows setting the other values in the license check configuration without having to supply a list of compatible licenses.

This resolves #720.