### PR TITLE
fix: Move TypeScript to peer dependency and allow >=4 <5.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
       "peerDependencies": {
         "eslint-config-es": "4.1.0",
         "npm-package-json-lint-config-tnw": "1.1.2",
-        "typescript": ">4.5 <5"
+        "typescript": ">=4 <5"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "spdx-satisfies": "5.0.1",
         "ts-node": "10.4.0",
         "type-fest": "2.12.0",
-        "typescript": "4.5.5",
         "validate-value": "9.2.2",
         "walk-file-tree": "1.0.37"
       },
@@ -56,14 +55,16 @@
         "isolated": "3.0.25",
         "react": "17.0.2",
         "semantic-release-configuration": "2.0.7",
-        "strip-ansi": "7.0.1"
+        "strip-ansi": "7.0.1",
+        "typescript": "4.5.5"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
         "eslint-config-es": "4.1.0",
-        "npm-package-json-lint-config-tnw": "1.1.2"
+        "npm-package-json-lint-config-tnw": "1.1.2",
+        "typescript": ">4.5 <5"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "spdx-satisfies": "5.0.1",
     "ts-node": "10.4.0",
     "type-fest": "2.12.0",
-    "typescript": "4.5.5",
     "validate-value": "9.2.2",
     "walk-file-tree": "1.0.37"
   },
@@ -86,11 +85,13 @@
     "isolated": "3.0.25",
     "react": "17.0.2",
     "semantic-release-configuration": "2.0.7",
-    "strip-ansi": "7.0.1"
+    "strip-ansi": "7.0.1",
+    "typescript": "4.5.5"
   },
   "peerDependencies": {
     "eslint-config-es": "4.1.0",
-    "npm-package-json-lint-config-tnw": "1.1.2"
+    "npm-package-json-lint-config-tnw": "1.1.2",
+    "typescript": ">=4 <5"
   },
   "scripts": {
     "roboter": "node --loader=ts-node/esm --experimental-specifier-resolution=node --no-warnings lib/bin/roboter.ts"

--- a/test/shared/fixtures/analyze/with-eslint-errors-in-typescript/package.json
+++ b/test/shared/fixtures/analyze/with-eslint-errors-in-typescript/package.json
@@ -8,9 +8,7 @@
   "types": "",
   "engines": {},
   "dependencies": {},
-  "devDependencies": {
-    "typescript": "3.5.3"
-  },
+  "devDependencies": {},
   "scripts": {},
   "repository": {},
   "keywords": [],


### PR DESCRIPTION
BREAKING CHANGE:
This will install a newer version of TypeScript than before. Since 4.6.2
is currently a breaking change compared to 4.5.5, this might require
action in your library.