### PR TITLE
exclude ts-jest from dependency usage checks, to prevent mis-reporting it as unused

### DIFF
--- a/lib/steps/dependencies/checkForUnusedDependencies.ts
+++ b/lib/steps/dependencies/checkForUnusedDependencies.ts
@@ -13,6 +13,7 @@ const checkForUnusedDependencies = async function ({ applicationRoot }: {
       'react',
       'roboter',
       'semantic-release-configuration',
+      'ts-jest',
       'ts-node',
       'tsconfig-paths',
       'typescript'


### PR DESCRIPTION
further description:
otherwise, ts-jest is reported unused,
since it is used only as jest test preset.
To also support projects that uses jest,
instead of mocha, or projects that uses both,
ts-jest should be excluded from deps usage check.